### PR TITLE
Raise a more useful error on bad animType, and fixed object drawing with goals where the object name didn't begin with [GOAL_X]

### DIFF
--- a/BlendToSMBStage2/descriptors.py
+++ b/BlendToSMBStage2/descriptors.py
@@ -293,6 +293,7 @@ class DescriptorIG(DescriptorBase):
         if animType == 0: animTypeStr = "PLAY_ONCE_ANIMATION"
         elif animType == 1: animTypeStr = "LOOPING_ANIMATION"
         elif animType == 2: animTypeStr = "SEESAW"
+        else: raise ValueError("Object " + obj.name + " has invalid anim type " + str(animType))
 
         animTypeE = etree.SubElement(xig, "animSeesawType")
         animTypeE.text = animTypeStr

--- a/BlendToSMBStage2/descriptors.py
+++ b/BlendToSMBStage2/descriptors.py
@@ -771,12 +771,14 @@ class DescriptorGoal(DescriptorBase):
 
     @staticmethod
     def get_object_type(obj):
-        types = {"B": "BLUE",
-                 "G": "GREEN",
-                 "R": "RED"}
-        goal_name = obj.name
-        goal_type = goal_name[6:goal_name.index(']')]
-        return types[goal_type]
+        if "[GOAL_B]" in obj.name:
+            return "BLUE"
+        elif "[GOAL_G]" in obj.name:
+            return "GREEN"
+        elif "[GOAL_R]" in obj.name:
+            return "RED"
+        else:
+            raise ValueError("Bad goal type for object " + obj.name)
 
 # List of all objects
 descriptors = [


### PR DESCRIPTION
Eg: An object with a name `[IG] [GOAL_B] The goal` would break object drawing, since `[GOAL_B]` wasn't the first thing in the object name.