### PR TITLE
Optimize animation export time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ws2lzfrontend/
 GxUtils/
 .idea/
 *.pyc
+.vscode/

--- a/BlendToSMBStage2/descriptors/descriptor_item_group.py
+++ b/BlendToSMBStage2/descriptors/descriptor_item_group.py
@@ -95,8 +95,7 @@ class DescriptorIG(DescriptorBase):
         etree.SubElement(grid, "count", x=str(obj["collisionStepCountX"]), z=str(obj["collisionStepCountY"]))
 
         # Add animation
-        if obj.animation_data is not None and obj.animation_data.action is not None:
-            generate_config.generate_anim_xml(ig_xml, anim_data)
+        generate_config.generate_anim_xml(ig_xml, anim_data)
 
         return ig_xml
 

--- a/BlendToSMBStage2/descriptors/descriptor_item_group.py
+++ b/BlendToSMBStage2/descriptors/descriptor_item_group.py
@@ -19,7 +19,7 @@ class DescriptorIG(DescriptorBase):
         return "[IG]"
 
     @staticmethod
-    def generate_xml(parent_element, obj):
+    def generate_xml_with_anim(parent_element, obj, anim_data):
         if "collisionStartX" not in obj.keys():
             raise Exception("Object " + obj.name + " is not a real item group! Try converting it into an item group, or renaming it.")
 
@@ -93,6 +93,8 @@ class DescriptorIG(DescriptorBase):
         etree.SubElement(grid, "start", x=str(obj["collisionStartX"]), z=str(obj["collisionStartY"]))
         etree.SubElement(grid, "step", x=str(obj["collisionStepX"]), z=str(obj["collisionStepY"]))
         etree.SubElement(grid, "count", x=str(obj["collisionStepCountX"]), z=str(obj["collisionStepCountY"]))
+
+        # TODO anim xml
 
         return xig
 

--- a/BlendToSMBStage2/descriptors/descriptor_item_group.py
+++ b/BlendToSMBStage2/descriptors/descriptor_item_group.py
@@ -24,17 +24,17 @@ class DescriptorIG(DescriptorBase):
             raise Exception("Object " + obj.name + " is not a real item group! Try converting it into an item group, or renaming it.")
 
         print("\tProcessing item group " + obj.name)
-        xig = etree.SubElement(parent_element, "itemGroup")
+        ig_xml = etree.SubElement(parent_element, "itemGroup")
 
         # Name
-        igName = etree.SubElement(xig, "name")
+        igName = etree.SubElement(ig_xml, "name")
         igName.text = obj.name
 
         # Position/Rotation
-        etree.SubElement(xig, "rotationCenter", x=str(obj.location.x),
+        etree.SubElement(ig_xml, "rotationCenter", x=str(obj.location.x),
                                                 y=str(obj.location.z),
                                                 z=str(-obj.location.y))
-        etree.SubElement(xig, "initialRotation", x=str(math.degrees(obj.rotation_euler.x)),
+        etree.SubElement(ig_xml, "initialRotation", x=str(math.degrees(obj.rotation_euler.x)),
                                                  y=str(math.degrees(obj.rotation_euler.z)),
                                                  z=str(math.degrees(-obj.rotation_euler.y)))
 
@@ -43,11 +43,11 @@ class DescriptorIG(DescriptorBase):
         if "animLoopTime" in obj.keys() and obj["animLoopTime"] != -1:
             loopTime = obj["animLoopTime"]
 
-        animLoopTime = etree.SubElement(xig, "animLoopTime")
+        animLoopTime = etree.SubElement(ig_xml, "animLoopTime")
         animLoopTime.text = str(loopTime) 
 
         # Animation ID
-        animIdE = etree.SubElement(xig, "animGroupId")
+        animIdE = etree.SubElement(ig_xml, "animGroupId")
         animIdE.text = str(obj["animId"])
 
         # Initial playing state
@@ -58,7 +58,7 @@ class DescriptorIG(DescriptorBase):
         elif animInitState == 3: animInitStateStr = "FAST_FORWARD"
         elif animInitState == 4: animInitStateStr = "REWIND"
         
-        animInitStateE = etree.SubElement(xig, "animInitialState")
+        animInitStateE = etree.SubElement(ig_xml, "animInitialState")
         animInitStateE.text = animInitStateStr
 
         # Type of animation
@@ -68,35 +68,37 @@ class DescriptorIG(DescriptorBase):
         elif animType == 2: animTypeStr = "SEESAW"
         else: raise ValueError("Object " + obj.name + " has invalid anim type " + str(animType))
 
-        animTypeE = etree.SubElement(xig, "animSeesawType")
+        animTypeE = etree.SubElement(ig_xml, "animSeesawType")
         animTypeE.text = animTypeStr
 
         # Conveyor speed
-        conv = etree.SubElement(xig, "conveyorSpeed", x=str(obj.get("conveyorX", 0.0)),
+        conv = etree.SubElement(ig_xml, "conveyorSpeed", x=str(obj.get("conveyorX", 0.0)),
                                                       y=str(obj.get("conveyorY", 0.0)),
                                                       z=str(obj.get("conveyorZ", 0.0)))
 
         # Seesaw properties
-        seesawSens = etree.SubElement(xig, "seesawSensitivity")
+        seesawSens = etree.SubElement(ig_xml, "seesawSensitivity")
         seesawSens.text = str(obj.get("seesawSensitivity", 0.0))
-        seesawFriction = etree.SubElement(xig, "seesawFriction")
+        seesawFriction = etree.SubElement(ig_xml, "seesawFriction")
         seesawFriction.text = str(obj.get("seesawFriction", 0.0)) 
-        seesawSpring = etree.SubElement(xig, "seesawSpring")
+        seesawSpring = etree.SubElement(ig_xml, "seesawSpring")
         seesawSpring.text = str(obj.get("seesawSpring", 0.0))
 
         # Texture scroll
-        texScroll = etree.SubElement(xig, "textureScroll", x=str(obj.get("texScrollUSpeed", 0.0)),
+        texScroll = etree.SubElement(ig_xml, "textureScroll", x=str(obj.get("texScrollUSpeed", 0.0)),
                                                            y=str(obj.get("texScrollVSpeed", 0.0)))
 
         # Collision grid start/step/count
-        grid = etree.SubElement(xig, "collisionGrid")
+        grid = etree.SubElement(ig_xml, "collisionGrid")
         etree.SubElement(grid, "start", x=str(obj["collisionStartX"]), z=str(obj["collisionStartY"]))
         etree.SubElement(grid, "step", x=str(obj["collisionStepX"]), z=str(obj["collisionStepY"]))
         etree.SubElement(grid, "count", x=str(obj["collisionStepCountX"]), z=str(obj["collisionStepCountY"]))
 
-        # TODO anim xml
+        # Add animation
+        if obj.animation_data is not None and obj.animation_data.action is not None:
+            generate_config.generate_anim_xml(ig_xml, anim_data)
 
-        return xig
+        return ig_xml
 
     @staticmethod
     def render(obj):

--- a/BlendToSMBStage2/descriptors/descriptor_model_bg.py
+++ b/BlendToSMBStage2/descriptors/descriptor_model_bg.py
@@ -55,8 +55,7 @@ class DescriptorBG(DescriptorBase):
             texScroll = etree.SubElement(bg_xml, "textureScroll", x=str(obj["texScrollUSpeed"]),
                                                                y=str(obj["texScrollVSpeed"]))
         # Add animation
-        if obj.animation_data is not None and obj.animation_data.action is not None:
-            generate_config.generate_anim_xml(bg_xml, anim_data)
+        generate_config.generate_anim_xml(bg_xml, anim_data)
 
     @staticmethod
     def construct(obj):

--- a/BlendToSMBStage2/descriptors/descriptor_model_bg.py
+++ b/BlendToSMBStage2/descriptors/descriptor_model_bg.py
@@ -17,46 +17,46 @@ class DescriptorBG(DescriptorBase):
         return "[BG]"
 
     @staticmethod
-    def generate_xml(parent_element, obj):
+    def generate_xml_with_anim(parent_element, obj, anim_data):
         print("\tBackground model: " + obj.name)
         
         # Export with pos/rot/scale if BG object has animation, otherwise don't
         if obj.animation_data is not None and obj.animation_data.action is not None:
-            bg = generate_config.generate_generic_obj_element(obj, "backgroundModel", parent_element, position=True, rotation=True, scale=True, name=False)
+            bg_xml = generate_config.generate_generic_obj_element(obj, "backgroundModel", parent_element, position=True, rotation=True, scale=True, name=False)
         else:
-            bg = generate_config.generate_generic_obj_element(obj, "backgroundModel", parent_element, position=True, rotation=True, scale=True, name=False, static_bg=True)
+            bg_xml = generate_config.generate_generic_obj_element(obj, "backgroundModel", parent_element, position=True, rotation=True, scale=True, name=False, static_bg=True)
 
         # Cleans up names
         if obj.data == None or obj.name == obj.data.name:
             if "[EXT:" in obj.name:
-                model = etree.SubElement(bg, "name")
+                model = etree.SubElement(bg_xml, "name")
                 model.text = re.search(r".*\[EXT:(.*)\].*", obj.name).group(1)
             else:
-                model = etree.SubElement(bg, "name")
+                model = etree.SubElement(bg_xml, "name")
                 model.text = obj.name.replace(" ", "_")
         else:
-            model = etree.SubElement(bg, "name")
+            model = etree.SubElement(bg_xml, "name")
             model.text = (obj.name + "_" + obj.data.name).replace(" ", "_")
 
         # Model mesh type
         if "meshType" in obj.keys():
-            meshTypeE = etree.SubElement(bg, "meshType")
+            meshTypeE = etree.SubElement(bg_xml, "meshType")
             meshTypeE.text = str(obj['meshType'])
 
         # Animation loop time
         if "animLoopTime" in obj.keys():
             loopTime = (bpy.context.scene.frame_end - bpy.context.scene.frame_start+1)/bpy.context.scene.render.fps
             if obj["animLoopTime"] != -1: loopTime = obj["animLoopTime"]
-            animLoopTimeE = etree.SubElement(bg, "animLoopTime")
+            animLoopTimeE = etree.SubElement(bg_xml, "animLoopTime")
             animLoopTimeE.text = str(loopTime)
                     
         # Texture scroll
         if "texScrollUSpeed" in obj.keys():
-            texScroll = etree.SubElement(bg, "textureScroll", x=str(obj["texScrollUSpeed"]),
+            texScroll = etree.SubElement(bg_xml, "textureScroll", x=str(obj["texScrollUSpeed"]),
                                                                y=str(obj["texScrollVSpeed"]))
         # Add animation
         if obj.animation_data is not None and obj.animation_data.action is not None:
-            generate_config.addAnimation(obj, bg)
+            generate_config.generate_anim_xml(bg_xml, anim_data)
 
     @staticmethod
     def construct(obj):

--- a/BlendToSMBStage2/descriptors/descriptor_model_fg.py
+++ b/BlendToSMBStage2/descriptors/descriptor_model_fg.py
@@ -17,46 +17,46 @@ class DescriptorFG(DescriptorBase):
         return "[FG]"
 
     @staticmethod
-    def generate_xml(parent_element, obj):
+    def generate_xml_with_anim(parent_element, obj, anim_data):
         print("\tForeground model: " + obj.name)
         
         # Export with pos/rot/scale if FG object has animation, otherwise don't
         if obj.animation_data is not None and obj.animation_data.action is not None:
-            fg = generate_config.generate_generic_obj_element(obj, "foregroundModel", parent_element, position=True, rotation=True, scale=True, name=False)
+            fg_xml = generate_config.generate_generic_obj_element(obj, "foregroundModel", parent_element, position=True, rotation=True, scale=True, name=False)
         else:
-            fg = generate_config.generate_generic_obj_element(obj, "foregroundModel", parent_element, position=True, rotation=True, scale=True, name=False, static_bg=True)
+            fg_xml = generate_config.generate_generic_obj_element(obj, "foregroundModel", parent_element, position=True, rotation=True, scale=True, name=False, static_bg=True)
 
         # Cleans up names
         if obj.data == None or obj.name == obj.data.name:
             if "[EXT:" in obj.name:
-                model = etree.SubElement(fg, "name")
+                model = etree.SubElement(fg_xml, "name")
                 model.text = re.search(r".*\[EXT:(.*)\].*", obj.name).group(1)
             else:
-                model = etree.SubElement(fg, "name")
+                model = etree.SubElement(fg_xml, "name")
                 model.text = obj.name.replace(" ", "_")
         else:
-            model = etree.SubElement(fg, "name")
+            model = etree.SubElement(fg_xml, "name")
             model.text = (obj.name + "_" + obj.data.name).replace(" ", "_")
 
         # Model mesh type
         if "meshType" in obj.keys():
-            meshTypeE = etree.SubElement(fg, "meshType")
+            meshTypeE = etree.SubElement(fg_xml, "meshType")
             meshTypeE.text = str(obj['meshType'])
 
         # Animation loop time
         if "animLoopTime" in obj.keys():
             loopTime = (bpy.context.scene.frame_end - bpy.context.scene.frame_start+1)/bpy.context.scene.render.fps
             if obj["animLoopTime"] != -1: loopTime = obj["animLoopTime"]
-            animLoopTimeE = etree.SubElement(fg, "animLoopTime")
+            animLoopTimeE = etree.SubElement(fg_xml, "animLoopTime")
             animLoopTimeE.text = str(loopTime)
                     
         # Texture scroll
         if "texScrollUSpeed" in obj.keys():
-            texScroll = etree.SubElement(fg, "textureScroll", x=str(obj["texScrollUSpeed"]),
+            texScroll = etree.SubElement(fg_xml, "textureScroll", x=str(obj["texScrollUSpeed"]),
                                                                y=str(obj["texScrollVSpeed"]))
         # Add animation
         if obj.animation_data is not None and obj.animation_data.action is not None:
-            generate_config.addAnimation(obj, fg)
+            generate_config.generate_anim_xml(fg_xml, anim_data)
 
     @staticmethod
     def construct(obj):

--- a/BlendToSMBStage2/descriptors/descriptor_model_fg.py
+++ b/BlendToSMBStage2/descriptors/descriptor_model_fg.py
@@ -55,8 +55,7 @@ class DescriptorFG(DescriptorBase):
             texScroll = etree.SubElement(fg_xml, "textureScroll", x=str(obj["texScrollUSpeed"]),
                                                                y=str(obj["texScrollVSpeed"]))
         # Add animation
-        if obj.animation_data is not None and obj.animation_data.action is not None:
-            generate_config.generate_anim_xml(fg_xml, anim_data)
+        generate_config.generate_anim_xml(fg_xml, anim_data)
 
     @staticmethod
     def construct(obj):

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -1,4 +1,4 @@
-from BlendToSMBStage2.stage_editor import AnimData
+from collections import defaultdict
 import bpy
 import sys
 import math
@@ -10,6 +10,25 @@ if platform == "linux" or platform == "linux2":
     from lxml import etree
 else:
     import xml.etree.ElementTree as etree
+
+class AnimData:
+    class Channel:
+        def __init__(self):
+            self.time_val_map = defaultdict({})
+            self.last_val = None
+
+    def __init__(self):
+        # float time -> float value
+        self.pos_x_channel = AnimData.Channel()
+        self.pos_y_channel = AnimData.Channel()
+        self.pos_z_channel = AnimData.Channel()
+        self.rot_x_channel = AnimData.Channel()
+        self.rot_y_channel = AnimData.Channel()
+        self.rot_z_channel = AnimData.Channel()
+        self.scale_x_channel = AnimData.Channel()
+        self.scale_y_channel = AnimData.Channel()
+        self.scale_z_channel = AnimData.Channel()
+
 
 # Generate an object entry with any of the following: position, rotation, scale 
 def generate_generic_obj_element(obj, obj_type, parent, *, position=False, rotation=False, scale=False, name=True, static_bg=False):

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -109,7 +109,7 @@ def _write_obj_prop_at_current_frame(obj, anim_channel: AnimData.Channel, obj_pr
     # Sets up custom per-object timestep if one is specified
     if "exportTimestep" in obj: 
         if obj["exportTimestep"] != -1:
-            timestep = bpy.context.view_layer.objects.active["exportTimestep"]
+            timestep = obj["exportTimestep"]
 
     curr_frame = bpy.context.scene.frame_current
     # Ignore out-of-range frames
@@ -173,8 +173,20 @@ def generate_per_frame_anim_data(obj, anim_data: AnimData):
     if fcurves.find("scale", index=2) is not None:
         _write_obj_prop_at_current_frame(obj, anim_data.scale_z_channel, obj.scale.z)
 
-def _generate_anim_channel_xml(parent_xml, anim_channel: AnimData.Channel):
-    pass
-
+def _generate_anim_channel_xml(parent_xml, anim_channel: AnimData.Channel, name):
+    if len(anim_channel.time_val_map) == 0:
+        return
+    
 def generate_anim_xml(parent_xml, anim_data: AnimData):
-    pass
+    keyframes_xml = etree.Element("animKeyframes")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_x_channel, "posX")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_y_channel, "posY")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_z_channel, "posZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_x_channel, "rotX")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_y_channel, "rotY")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_z_channel, "rotZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_x_channel, "scaleX")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_y_channel, "scaleY")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_z_channel, "scaleZ")
+    if len(keyframes_xml) > 0:
+        parent_xml.append(keyframes_xml)

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -85,7 +85,6 @@ def addKeyframes(parent, selector, fcurve):
         bpy.context.scene.frame_set(i)
         seconds = round((i-start_frame)/bpy.context.scene.render.fps, bpy.context.scene.export_time_round)
         val = round(selector(bpy.context.view_layer.objects.active), bpy.context.scene.export_value_round)
-        current_fcurve = fcurve(bpy.context.view_layer.objects.active.animation_data.action)
 
         if (optimize and (val == prev_val)):
             continue

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -177,14 +177,15 @@ def _generate_anim_channel_xml(parent_xml, anim_channel: AnimData.Channel, name)
     
 def generate_anim_xml(parent_xml, anim_data: AnimData):
     keyframes_xml = etree.Element("animKeyframes")
+    # Y and Z need to be swapped for some reason?
     _generate_anim_channel_xml(keyframes_xml, anim_data.pos_x_channel, "posX")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_y_channel, "posY")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_z_channel, "posZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_y_channel, "posZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.pos_z_channel, "posY")
     _generate_anim_channel_xml(keyframes_xml, anim_data.rot_x_channel, "rotX")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_y_channel, "rotY")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_z_channel, "rotZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_y_channel, "rotZ") 
+    _generate_anim_channel_xml(keyframes_xml, anim_data.rot_z_channel, "rotY")
     _generate_anim_channel_xml(keyframes_xml, anim_data.scale_x_channel, "scaleX")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_y_channel, "scaleY")
-    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_z_channel, "scaleZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_y_channel, "scaleZ")
+    _generate_anim_channel_xml(keyframes_xml, anim_data.scale_z_channel, "scaleY")
     if len(keyframes_xml) > 0:
         parent_xml.append(keyframes_xml)

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -77,12 +77,14 @@ def addKeyframes(parent, selector, fcurve):
                 
                 keyframes[seconds] = value
 
+    bpy.context.scene.frame_set(0)
     prev_val = None
     
     # Iterates through the animation to add intermediate (non-explictly defined) keyframes
     for i in range(start_frame, end_frame+1, timestep):
+        bpy.context.scene.frame_set(i)
         seconds = round((i-start_frame)/bpy.context.scene.render.fps, bpy.context.scene.export_time_round)
-        val = round(current_fcurve.evaluate(i), bpy.context.scene.export_value_round)
+        val = round(selector(bpy.context.view_layer.objects.active), bpy.context.scene.export_value_round)
 
         if (optimize and (val == prev_val)):
             continue

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -120,8 +120,8 @@ def _write_obj_prop_at_current_frame(obj, anim_channel: AnimData.Channel, obj_pr
     val = round(obj_prop, bpy.context.scene.export_value_round)
     if (optimize and (val == anim_channel.prev_val)):
         return
-
     anim_channel.prev_val = val
+
     if seconds not in anim_channel.time_val_map:
         anim_channel.time_val_map[seconds] = val
 
@@ -172,6 +172,9 @@ def generate_per_frame_anim_data(obj, anim_data: AnimData):
         _write_obj_prop_at_current_frame(obj, anim_data.scale_y_channel, obj.scale.y)
     if fcurves.find("scale", index=2) is not None:
         _write_obj_prop_at_current_frame(obj, anim_data.scale_z_channel, obj.scale.z)
+
+def _generate_anim_channel_xml(parent_xml, anim_channel: AnimData.Channel):
+    pass
 
 def generate_anim_xml(parent_xml, anim_data: AnimData):
     pass

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -1,6 +1,4 @@
-from collections import defaultdict
 import bpy
-import sys
 import math
 from sys import platform
 

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -77,14 +77,12 @@ def addKeyframes(parent, selector, fcurve):
                 
                 keyframes[seconds] = value
 
-    bpy.context.scene.frame_set(0)
     prev_val = None
     
     # Iterates through the animation to add intermediate (non-explictly defined) keyframes
     for i in range(start_frame, end_frame+1, timestep):
-        bpy.context.scene.frame_set(i)
         seconds = round((i-start_frame)/bpy.context.scene.render.fps, bpy.context.scene.export_time_round)
-        val = round(selector(bpy.context.view_layer.objects.active), bpy.context.scene.export_value_round)
+        val = round(current_fcurve.evaluate(i), bpy.context.scene.export_value_round)
 
         if (optimize and (val == prev_val)):
             continue

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -59,18 +59,6 @@ def generate_generic_obj_element(obj, obj_type, parent, *, position=False, rotat
 
     return sub
 
-# Generates an XML keyframe list for the specified axis and fcurve type
-def addKeyframes(parent, selector, fcurve):
-    # Create sorted XML keyframe list
-    for time in sorted(list(keyframes.keys())):
-        val = keyframes[time]
-
-        keyframe = etree.Element("keyframe")
-        keyframe.set("time", str(time))
-        keyframe.set("value", str(val))
-        keyframe.set("easing", "LINEAR")
-        parent.append(keyframe)
-
 def _write_fcurve_keyframe_values(obj, anim_channel: AnimData.Channel, fcurve):
     start_frame = bpy.context.scene.frame_start
     end_frame = bpy.context.scene.frame_end
@@ -176,6 +164,16 @@ def generate_per_frame_anim_data(obj, anim_data: AnimData):
 def _generate_anim_channel_xml(parent_xml, anim_channel: AnimData.Channel, name):
     if len(anim_channel.time_val_map) == 0:
         return
+    channel_xml = etree.SubElement(parent_xml, name)
+
+    # Create sorted XML keyframe list
+    for time in sorted(list(anim_channel.time_val_map.keys())):
+        val = anim_channel.time_val_map[time]
+        keyframe_xml = etree.SubElement(channel_xml, "keyframe")
+        keyframe_xml.set("time", str(time))
+        keyframe_xml.set("value", str(val))
+        keyframe_xml.set("easing", "LINEAR")
+
     
 def generate_anim_xml(parent_xml, anim_data: AnimData):
     keyframes_xml = etree.Element("animKeyframes")

--- a/BlendToSMBStage2/generate_config.py
+++ b/BlendToSMBStage2/generate_config.py
@@ -1,3 +1,4 @@
+from BlendToSMBStage2.stage_editor import AnimData
 import bpy
 import sys
 import math
@@ -104,102 +105,53 @@ def addKeyframes(parent, selector, fcurve):
         keyframe.set("easing", "LINEAR")
         parent.append(keyframe)
 
-def addPosXAnim(parent):
-    addKeyframes(parent, lambda i: i.location.x, lambda f: f.fcurves.find("location", index=0))
+def _write_fcurve_keyframe_values(anim_data: AnimData, fcurve):
+    pass
 
-def addPosYAnim(parent):
-    addKeyframes(parent,lambda i: -i.location.y, lambda f: f.fcurves.find("location", index=1))
+def _write_obj_prop_at_current_frame(anim_data: AnimData, ig_obj_prop):
+    pass
 
-def addPosZAnim(parent):
-    addKeyframes(parent,lambda i: i.location.z, lambda f: f.fcurves.find("location", index=2))
+def generate_keyframe_anim_data(ig_obj, ig_anim: AnimData):
+    fcurves = ig_obj.animation_data.action.fcurves
+    if fcurve := fcurves.find("location", index=0) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.pos_x_channel, fcurve)
+    if fcurve := fcurves.find("location", index=1) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.pos_y_channel, fcurve)
+    if fcurve := fcurves.find("location", index=2) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.pos_z_channel, fcurve)
+    if fcurve := fcurves.find("rotation_euler", index=0) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.rot_x_channel, fcurve)
+    if fcurve := fcurves.find("rotation_euler", index=1) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.rot_y_channel, fcurve)
+    if fcurve := fcurves.find("rotation_euler", index=2) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.rot_z_channel, fcurve)
+    if fcurve := fcurves.find("scale", index=0) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.scale_x_channel, fcurve)
+    if fcurve := fcurves.find("scale", index=1) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.scale_y_channel, fcurve)
+    if fcurve := fcurves.find("scale", index=2) is not None:
+        _write_fcurve_keyframe_values(ig_obj, ig_anim.scale_z_channel, fcurve)
 
-def addRotXAnim(parent):
-    addKeyframes(parent,lambda i: math.degrees(i.rotation_euler.x), lambda f: f.fcurves.find("rotation_euler", index=0))
+def generate_per_frame_anim_data(ig_obj, ig_anim: AnimData):
+    fcurves = ig_obj.animation_data.action.fcurves
+    if fcurves.find("location", index=0) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.pos_x_channel, ig_obj.location.x)
+    if fcurves.find("location", index=1) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.pos_y_channel, -ig_obj.location.y)
+    if fcurves.find("location", index=2) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.pos_z_channel, ig_obj.location.z)
+    if fcurves.find("rotation_euler", index=0) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.rot_x_channel, math.degrees(ig_obj.rotation_euler.x))
+    if fcurves.find("rotation_euler", index=1) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.rot_y_channel, -math.degrees(ig_obj.rotation_euler.y))
+    if fcurves.find("rotation_euler", index=2) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.rot_z_channel, math.degrees(i.rotation_euler.z))
+    if fcurves.find("scale", index=0) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.scale_x_channel, ig_obj.scale.x)
+    if fcurves.find("scale", index=1) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.scale_y_channel, ig_obj.scale.y)
+    if fcurves.find("scale", index=2) is not None:
+        _write_obj_prop_at_current_frame(ig_anim.scale_z_channel, ig_obj.scale.z)
 
-def addRotYAnim(parent):
-    addKeyframes(parent,lambda i: -math.degrees(i.rotation_euler.y), lambda f: f.fcurves.find("rotation_euler", index=1))
-
-def addRotZAnim(parent):
-    addKeyframes(parent,lambda i: math.degrees(i.rotation_euler.z), lambda f: f.fcurves.find("rotation_euler", index=2))
-
-def addScaleXAnim(parent):
-    addKeyframes(parent, lambda i: i.scale.x, lambda f: f.fcurves.find("scale", index=0))
-
-def addScaleYAnim(parent):
-    addKeyframes(parent,lambda i: i.scale.y, lambda f: f.fcurves.find("scale", index=1))
-
-def addScaleZAnim(parent):
-    addKeyframes(parent,lambda i: i.scale.z, lambda f: f.fcurves.find("scale", index=2))
-
-def addAnimation(obj, parent):
-    print("\tChecking for animation...")
-    bpy.context.view_layer.objects.active = obj
-
-    animKeyframes = etree.Element("animKeyframes")
-    hasInserted = False
-
-    fcurves = obj.animation_data.action.fcurves
-
-    if fcurves.find("location", index=0):
-        print("\t\tAdding X Pos keyframes...")
-        posX = etree.SubElement(animKeyframes, "posX")
-        addPosXAnim(posX)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("location", index=1):
-        print("\t\tAdding Y Pos keyframes...")
-        posZ = etree.SubElement(animKeyframes, "posZ")
-        addPosYAnim(posZ)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("location", index=2):
-        print("\t\tAdding Z Pos keyframes...")
-        posY = etree.SubElement(animKeyframes, "posY")
-        addPosZAnim(posY)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("rotation_euler", index=0):
-        print("\t\tAdding X Rot keyframes...")
-        rotX = etree.SubElement(animKeyframes, "rotX")
-        addRotXAnim(rotX)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("rotation_euler", index=1):
-        print("\t\tAdding Y Rot keyframes...")
-        rotZ = etree.SubElement(animKeyframes, "rotZ")
-        addRotYAnim(rotZ)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("rotation_euler", index=2):
-        print("\t\tAdding Z Rot keyframes...")
-        rotY = etree.SubElement(animKeyframes, "rotY")
-        addRotZAnim(rotY)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("scale", index=0):
-        print("\t\tAdding X Scale keyframes...")
-        scaleX = etree.SubElement(animKeyframes, "scaleX")
-        addScaleXAnim(scaleX)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("scale", index=1):
-        print("\t\tAdding Y Scale keyframes...")
-        scaleZ = etree.SubElement(animKeyframes, "scaleZ")
-        addScaleYAnim(scaleZ)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True
-    if fcurves.find("scale", index=2):
-        print("\t\tAdding Z Scale keyframes...")
-        scaleY = etree.SubElement(animKeyframes, "scaleY")
-        addScaleZAnim(scaleY)
-        if not hasInserted:
-            parent.append(animKeyframes)
-            hasInserted = True 
+def generate_anim_xml(parent_xml, anim_data: AnimData):
+    pass

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1638,15 +1638,25 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         bg_export_datas: list[ObjExport] = []
         other_export_datas: list[ObjExport] = []
 
+        ig_tag = descriptor_item_group.DescriptorIG.get_object_name()
+        fg_tag = descriptor_model_fg.DescriptorFG.get_object_name()
+        bg_tag = descriptor_model_bg.DescriptorBG.get_object_name()
+
         for obj in bpy.context.scene.objects:
             if obj.type not in ["EMPTY", "MESH", "CURVE"]:
                 continue
-            if "[IG]" in obj.name and 'collisionStartX' in obj.keys(): # Is .keys() needed?
-                ig_export_datas.append(ObjExport(obj))
-            elif obj.name.startswith(descriptor_model_fg.DescriptorFG.get_object_name()):
-                fg_export_datas.append(ObjExport(obj))
-            elif obj.name.startswith(descriptor_model_bg.DescriptorBG.get_object_name()):
-                bg_export_datas.append(ObjExport(obj))
+            if ig_tag in obj.name:
+                # Don't export at all otherwise
+                if 'collisionStartX' in obj:
+                    ig_export_datas.append(ObjExport(obj))
+            elif fg_tag in obj.name:
+                # Don't export at all otherwise
+                if obj.name.startswith(descriptor_model_fg.DescriptorFG.get_object_name()):
+                    fg_export_datas.append(ObjExport(obj))
+            elif bg_tag in obj.name:
+                # Don't export at all otherwise
+                if obj.name.startswith(descriptor_model_bg.DescriptorBG.get_object_name()):
+                    bg_export_datas.append(ObjExport(obj))
             else:
                 other_export_datas.append(ObjExport(obj))
 

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1694,10 +1694,12 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         # Generate per-global-frame animation data
         start_frame = bpy.context.scene.frame_start
         end_frame = bpy.context.scene.frame_end
+        orig_frame = bpy.context.scene.frame_current
         for frame in range(start_frame, end_frame + 1):
             bpy.context.scene.frame_set(frame)
             for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
                 generate_config.generate_per_frame_anim_data(exp.obj, exp.anim_data)
+        bpy.context.scene.frame_set(orig_frame)
 
         # Generate itemgroup XML
         for ig_exp in ig_export_datas:

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1643,9 +1643,9 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
                 continue
             if "[IG]" in obj.name and 'collisionStartX' in obj.keys(): # Is .keys() needed?
                 ig_export_datas.append(ObjExport(obj))
-            elif "[FG]" in obj.name:
+            elif obj.name.startswith(descriptor_model_fg.DescriptorFG.get_object_name()):
                 fg_export_datas.append(ObjExport(obj))
-            elif "[BG]" in obj.name:
+            elif obj.name.startswith(descriptor_model_bg.DescriptorBG.get_object_name()):
                 bg_export_datas.append(ObjExport(obj))
             else:
                 other_export_datas.append(ObjExport(obj))

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -15,8 +15,7 @@ import locale
 from . import statics, stage_object_drawing, generate_config, dimension_dict
 
 from .descriptors import descriptors, descriptor_item_group, descriptor_model_stage, descriptor_track_path, descriptor_model_bg, descriptor_model_fg
-from bpy.props import BoolProperty, PointerProperty, EnumProperty, FloatProperty, FloatVectorProperty, ntProperty
-from enum import Enum
+from bpy.props import BoolProperty, PointerProperty, EnumProperty, FloatProperty, FloatVectorProperty, IntProperty
 from sys import platform
 from mathutils import Vector, Matrix
 

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+import itertools
+from BlendToSMBStage2.descriptors import descriptor_model_bg, descriptor_model_fg
 import bpy
 import bgl
 import bmesh
@@ -1540,6 +1543,25 @@ def append_imported_bg_objects(self, context, bg_root, dest_root, obj_names):
 
         dest_root.append(imported_bg_model)
 
+class AnimData:
+    class Channel:
+        def __init__(self):
+            self.time_val_map = defaultdict({})
+            self.last_val = None
+
+    def __init__(self):
+        # float time -> float value
+        self.pos_x_channel = AnimData.Channel()
+        self.pos_y_channel = AnimData.Channel()
+        self.pos_z_channel = AnimData.Channel()
+        self.rot_x_channel = AnimData.Channel()
+        self.rot_y_channel = AnimData.Channel()
+        self.rot_z_channel = AnimData.Channel()
+        self.scale_x_channel = AnimData.Channel()
+        self.scale_y_channel = AnimData.Channel()
+        self.scale_z_channel = AnimData.Channel()
+
+
 # Operator for exporting the stage config as a .XML file
 class OBJECT_OT_generate_config(bpy.types.Operator):
     bl_idname = "object.generate_config"
@@ -1625,100 +1647,112 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
             for i in [0, 1, 2]:
                 all_curve_types.append((i, ct))
 
-        # Iterate over all top-level objects
-        for obj in [obj for obj in bpy.context.scene.objects if (obj.type == 'EMPTY' or obj.type == 'MESH' or obj.type == 'CURVE')]:
+        # TODO
+        # Apply fcurve keyframe hack to IG/FG/BG objs
+        # Generate animation data for all IG/FG/BG
+        # Generate XML for all objects
+        #  For IG/FG/BG, call special descriptor method that takes anim data
+        # Undo keyframe hack
 
-            # Add first keyframe to IGs, BGs, and FGs
-            # Also add IGs to the IG list
-            if any(animatable in obj.name for animatable in ["[IG]", "[BG]", "[FG]"]): 
-                context.scene.frame_set(begin_frame)
+        class ObjExport:
+            def __init__(self, obj):
+                self.obj = obj
+                self.anim_data = AnimData()
+    
+        # Build ObjExport lists
+        ig_export_datas = []
+        fg_export_datas = []
+        bg_export_datas = []
+        other_export_datas = []
 
-                if "[IG]" in obj.name: igs.append(obj)
-
-                # Semi-hacky way to get the object's center of rotation to work properly
-                # B2SMB1 inadvertently fixed this by baking *all* keyframes
-                # This is fixed by adding an initial keyframe on every curve
-                # This also fixes weirdness with background and foreground objects
-                if obj.animation_data is not None and obj.animation_data.action is not None:
-                    first_keyframe_exists = False
-                    existing_channels = []
-                    fcurves = obj.animation_data.action.fcurves
-
-                    # Find existing channels with frame 0 keyframes
-                    for (index, curve_type) in all_curve_types:
-                        fcurve = fcurves.find(curve_type, index=index)
-                        if fcurve is not None:
-                            for keyframe_index in range(len(fcurve.keyframe_points)):
-                                if fcurve.keyframe_points[keyframe_index].co[0] == float(begin_frame):
-                                    existing_channels.append((index, curve_type))
-                                    # print(f"Added existing channel {curve_type}[{index}]")
-                                    break
-
-                    # If not all of the channels have frame 0 keyframes, we need to add frame 0 keyframes on those channels
-                    if len(existing_channels) != 9:
-                        first_frame_added_objs.append((obj, existing_channels))
-                   
-                    # We just add frame 0 keyframes on all needed channels, and use existing_chanenls to find out what needs to be removed after export
-                    for curve_type in curve_types:
-                        obj.keyframe_insert(curve_type, frame=begin_frame, options = {'INSERTKEY_NEEDED'})
-
-                    print("\tInserted frame zero keyframe for item group " + obj.name)
-                
-                # Generate XML elements for BG and FG objects
-                if "[IG]" not in obj.name:
-                    for desc in descriptors.descriptors_root:
-                        match_descriptor = False
-                        if obj.name.startswith(desc.get_object_name()): 
-                            match_descriptor = True
-                            desc.generate_xml(root, obj)
-                            continue
-
-            # Handle non-animated BG/FG objects
-            else:
-                # Non-item groups (start, BG/FG objects, etc)
-                for desc in descriptors.descriptors_root:
-                    match_descriptor = False
-                    if obj.name.startswith(desc.get_object_name()): 
-                        match_descriptor = True
-                        desc.generate_xml(root, obj)
-                        continue
-
-        # Iterate over all item groups
-        for ig in igs: 
-            context.scene.frame_set(begin_frame)
-            # Children list
-            ig_children = [obj for obj in bpy.context.scene.objects if obj.parent == ig]
-            ig_children.append(ig)
-
-            # Generate item group XML elements
-            if 'collisionStartX' in ig.keys():
-                xig = descriptor_item_group.DescriptorIG.generate_xml(root, ig)
-
-            else:
+        for obj in bpy.context.scene.objects:
+            if obj.type not in ["EMPTY", "MESH", "CURVE"]:
                 continue
+            if "[IG]" in obj.name and 'collisionStartX' in ig.keys(): # Is .keys() needed?
+                ig_export_datas.append(ObjExport(obj))
+            elif "[FG]" in obj.name:
+                fg_export_datas.append(ObjExport(obj))
+            elif "[BG]" in obj.name:
+                bg_export_datas.append(ObjExport(obj))
+            else:
+                other_export_datas.append(ObjExport(obj))
 
-            # Animation
-            if ig.animation_data is not None and ig.animation_data.action is not None:
-                generate_config.addAnimation(ig, xig)
+        # Semi-hacky way to get the object's center of rotation to work properly
+        # B2SMB1 inadvertently fixed this by baking *all* keyframes
+        # This is fixed by adding an initial keyframe on every curve
+        # This also fixes weirdness with background and foreground objects
+        for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
+            if exp.obj.animation_data is not None and exp.obj.animation_data.action is not None:
+                first_keyframe_exists = False
+                existing_channels = []
+                fcurves = exp.obj.animation_data.action.fcurves
+
+                # Find existing channels with frame 0 keyframes
+                for (index, curve_type) in all_curve_types:
+                    fcurve = fcurves.find(curve_type, index=index)
+                    if fcurve is not None:
+                        for keyframe_index in range(len(fcurve.keyframe_points)):
+                            if fcurve.keyframe_points[keyframe_index].co[0] == float(begin_frame):
+                                existing_channels.append((index, curve_type))
+                                # print(f"Added existing channel {curve_type}[{index}]")
+                                break
+
+                # If not all of the channels have frame 0 keyframes, we need to add frame 0 keyframes on those channels
+                if len(existing_channels) != 9:
+                    first_frame_added_objs.append((exp.obj, existing_channels))
+                
+                # We just add frame 0 keyframes on all needed channels, and use existing_chanenls to find out what needs to be removed after export
+                for curve_type in curve_types:
+                    exp.obj.keyframe_insert(curve_type, frame=begin_frame, options = {'INSERTKEY_NEEDED'})
+
+                print("\tInserted frame zero keyframe for item group " + exp.obj.name)
+
+        # TODO This needs to go somewhere...
+        # if ig.animation_data is not None and ig.animation_data.action is not None:
+        #     generate_config.addAnimation(ig, xig)
+
+        # Generate initial animation data based on fcurce keyframes
+        for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
+            pass
+        # Generate per-global-frame animation data
+        # TODO step global frame appropriately based on start/end/step etc
+        for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
+            pass
+
+        # Generate itemgroup XML
+        for ig_exp in ig_export_datas:
+            ig_xml = descriptor_item_group.DescriptorIG.generate_xml_with_anim(root, ig_exp.obj, ig_exp.anim_data)
+
+            # Children list
+            ig_children = [obj for obj in bpy.context.scene.objects if obj.parent == ig_exp.obj]
+            ig_children.append(ig_exp.obj)
 
             # Children of item groups
             for child in ig_children:
-                context.scene.frame_set(begin_frame)
                 match_descriptor = False
 
                 # Generate elements for listed descriptors (except IGs)
                 for desc in descriptors.descriptors:
                     if desc.get_object_name() in child.name and "[IG]" not in child.name:
                         match_descriptor = True
-                        desc.generate_xml(xig, child)
+                        desc.generate_xml(ig_xml, child)
                         break
                 
                 # Object is not a listed descriptor
                 if not match_descriptor and child.data is not None:
-                        descriptor_model_stage.DescriptorModel.generate_xml(xig, child)
+                    descriptor_model_stage.DescriptorModel.generate_xml(ig_xml, child)
+        
+        # Generate FG/BG XML
+        for fg_exp in fg_export_datas:
+            descriptor_model_fg.generate_xml_with_anim_data(root, fg_exp.obj, fg_exp.anim_data)
+        for bg_exp in bg_export_datas:
+            descriptor_model_bg.generate_xml_with_anim_data(root, bg_exp.obj, bg_exp.anim_data)
 
-
-        context.scene.frame_set(begin_frame)
+        # Generate other object XML
+        for other_exp in other_export_datas:
+            for desc in descriptors.descriptors_root:
+                if other_exp.obj.name.startswith(desc.get_object_name()): 
+                    desc.generate_xml(root, other_exp.obj)
 
         # Import background and foreground objects from a .XML file, if it exists
         bg_path = bpy.path.abspath(context.scene.background_import_path)

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1667,7 +1667,6 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         # B2SMB1 inadvertently fixed this by baking *all* keyframes
         # This is fixed by adding an initial keyframe on every curve
         # This also fixes weirdness with background and foreground objects
-        context.scene.frame_set(begin_frame)
         for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
             if exp.obj.animation_data is not None and exp.obj.animation_data.action is not None:
                 existing_channels = []

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1666,7 +1666,6 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         # This also fixes weirdness with background and foreground objects
         for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
             if exp.obj.animation_data is not None and exp.obj.animation_data.action is not None:
-                first_keyframe_exists = False
                 existing_channels = []
                 fcurves = exp.obj.animation_data.action.fcurves
 

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1627,13 +1627,6 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
             for i in [0, 1, 2]:
                 all_curve_types.append((i, ct))
 
-        # TODO
-        # Apply fcurve keyframe hack to IG/FG/BG objs
-        # Generate animation data for all IG/FG/BG
-        # Generate XML for all objects
-        #  For IG/FG/BG, call special descriptor method that takes anim data
-        # Undo keyframe hack
-
         class ObjExport:
             def __init__(self, obj):
                 self.obj = obj
@@ -1695,11 +1688,13 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         start_frame = bpy.context.scene.frame_start
         end_frame = bpy.context.scene.frame_end
         orig_frame = bpy.context.scene.frame_current
-        for frame in range(start_frame, end_frame + 1):
-            bpy.context.scene.frame_set(frame)
-            for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
-                generate_config.generate_per_frame_anim_data(exp.obj, exp.anim_data)
-        bpy.context.scene.frame_set(orig_frame)
+        try:
+            for frame in range(start_frame, end_frame + 1):
+                bpy.context.scene.frame_set(frame)
+                for exp in itertools.chain(ig_export_datas, fg_export_datas, bg_export_datas):
+                    generate_config.generate_per_frame_anim_data(exp.obj, exp.anim_data)
+        finally:
+            bpy.context.scene.frame_set(orig_frame)
 
         # Generate itemgroup XML
         for ig_exp in ig_export_datas:

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1706,6 +1706,18 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         finally:
             bpy.context.scene.frame_set(orig_frame)
 
+        # Generate FG/BG XML
+        for fg_exp in fg_export_datas:
+            descriptor_model_fg.DescriptorFG.generate_xml_with_anim(root, fg_exp.obj, fg_exp.anim_data)
+        for bg_exp in bg_export_datas:
+            descriptor_model_bg.DescriptorBG.generate_xml_with_anim(root, bg_exp.obj, bg_exp.anim_data)
+
+        # Generate other object XML
+        for other_exp in other_export_datas:
+            for desc in descriptors.descriptors_root:
+                if other_exp.obj.name.startswith(desc.get_object_name()): 
+                    desc.generate_xml(root, other_exp.obj)
+
         # Generate itemgroup XML
         for ig_exp in ig_export_datas:
             ig_xml = descriptor_item_group.DescriptorIG.generate_xml_with_anim(root, ig_exp.obj, ig_exp.anim_data)
@@ -1728,18 +1740,6 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
                 # Object is not a listed descriptor
                 if not match_descriptor and child.data is not None:
                     descriptor_model_stage.DescriptorModel.generate_xml(ig_xml, child)
-        
-        # Generate FG/BG XML
-        for fg_exp in fg_export_datas:
-            descriptor_model_fg.DescriptorFG.generate_xml_with_anim(root, fg_exp.obj, fg_exp.anim_data)
-        for bg_exp in bg_export_datas:
-            descriptor_model_bg.DescriptorBG.generate_xml_with_anim(root, bg_exp.obj, bg_exp.anim_data)
-
-        # Generate other object XML
-        for other_exp in other_export_datas:
-            for desc in descriptors.descriptors_root:
-                if other_exp.obj.name.startswith(desc.get_object_name()): 
-                    desc.generate_xml(root, other_exp.obj)
 
         # Import background and foreground objects from a .XML file, if it exists
         bg_path = bpy.path.abspath(context.scene.background_import_path)

--- a/BlendToSMBStage2/stage_editor.py
+++ b/BlendToSMBStage2/stage_editor.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import itertools
 from BlendToSMBStage2.descriptors import descriptor_model_bg, descriptor_model_fg
 import bpy
@@ -1543,24 +1542,6 @@ def append_imported_bg_objects(self, context, bg_root, dest_root, obj_names):
 
         dest_root.append(imported_bg_model)
 
-class AnimData:
-    class Channel:
-        def __init__(self):
-            self.time_val_map = defaultdict({})
-            self.last_val = None
-
-    def __init__(self):
-        # float time -> float value
-        self.pos_x_channel = AnimData.Channel()
-        self.pos_y_channel = AnimData.Channel()
-        self.pos_z_channel = AnimData.Channel()
-        self.rot_x_channel = AnimData.Channel()
-        self.rot_y_channel = AnimData.Channel()
-        self.rot_z_channel = AnimData.Channel()
-        self.scale_x_channel = AnimData.Channel()
-        self.scale_y_channel = AnimData.Channel()
-        self.scale_z_channel = AnimData.Channel()
-
 
 # Operator for exporting the stage config as a .XML file
 class OBJECT_OT_generate_config(bpy.types.Operator):
@@ -1657,7 +1638,7 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         class ObjExport:
             def __init__(self, obj):
                 self.obj = obj
-                self.anim_data = AnimData()
+                self.anim_data = generate_config.AnimData()
     
         # Build ObjExport lists
         ig_export_datas = []
@@ -1668,7 +1649,7 @@ class OBJECT_OT_generate_config(bpy.types.Operator):
         for obj in bpy.context.scene.objects:
             if obj.type not in ["EMPTY", "MESH", "CURVE"]:
                 continue
-            if "[IG]" in obj.name and 'collisionStartX' in ig.keys(): # Is .keys() needed?
+            if "[IG]" in obj.name and 'collisionStartX' in obj.keys(): # Is .keys() needed?
                 ig_export_datas.append(ObjExport(obj))
             elif "[FG]" in obj.name:
                 fg_export_datas.append(ObjExport(obj))


### PR DESCRIPTION
This speeds up exporting stage animations. On a stage with many long animations, it previously took 6m 4s to export config on my laptop and now takes 7.65s (~50X speedup).

The core optimization is turning:

```
for each animation channel:
    for each frame i:
        frame_set(i)
        export animation frame
```

into:

```
for each frame i:
    frame_set(i)
    for each animation channel:
        export animation frame
```

`bpy.context.scene.frame_set()` is expensive because it updates every object in the scene, so this change only iterates over scene frames once.

I tested by exporting said stage with many long itemgroup animations and comparing the XML with master and it compares identical aside from some 0.0 / -0.0 sign flips. Some stages with fg/bg animations probably need to be tested in addition though.